### PR TITLE
TCANDROID-66745: Update the sample app with OAuth SDK 3.2.1

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -52,7 +52,7 @@ dependencies {
     implementation("com.squareup.retrofit2:converter-gson:2.10.0")
     implementation("com.squareup.okhttp3:logging-interceptor:4.12.0")
 
-    implementation("com.truecaller.android.sdk:truecaller-sdk:3.2.0")
+    implementation("com.truecaller.android.sdk:truecaller-sdk:3.2.1")
 
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.2.1")

--- a/app/src/main/java/com/example/testoauth/ui/login/SignedInActivity.java
+++ b/app/src/main/java/com/example/testoauth/ui/login/SignedInActivity.java
@@ -42,7 +42,9 @@ public class SignedInActivity extends Activity {
         binding.accessTokenBtn.setOnClickListener(view -> fetchAccessToken(oAuthData, codeVerifier));
         binding.signedInTv.setText(String.format(getString(R.string.large_text),
                 oAuthData.getAuthorizationCode(), codeVerifier,
-                oAuthData.getState(), requestedState, oAuthData.getScopesGranted()));
+                oAuthData.getState(), requestedState, oAuthData.getScopesGranted(),
+                oAuthData.getSimState() + "", oAuthData.getDeviceCode()
+        ));
         createRetrofitService();
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,6 +11,8 @@
         State is %3$s\n\n
         Requested State is %4$s\n\n
         Scopes granted are %5$s\n\n
+        Sim State is %6$s\n\n
+        Device Code is %7$s\n\n
         --------------------------------------------------------------->>>
     </string>
     <string name="access_token">Access Token is %s</string>


### PR DESCRIPTION

# Description
Bumb OAuth SDK version to latest 3.2.1
Add simState and DeviceCode in OAuth success UI so that it will easy for QA to test new features.
# Demo
<img width="247" height="204" alt="image" src="https://github.com/user-attachments/assets/8fa6e89b-12ec-4b76-ac79-75ef359f44d1" />
<img width="239" height="483" alt="image" src="https://github.com/user-attachments/assets/82a0f2ed-2aa1-41cc-b2c1-a7daf1e2e163" />
<img width="253" height="206" alt="image" src="https://github.com/user-attachments/assets/3f3f03f7-01cf-4608-98a3-0e716952afa7" />
<img width="238" height="261" alt="image" src="https://github.com/user-attachments/assets/7ccf903e-c53e-4707-a568-b624ca8cea44" />
